### PR TITLE
Extend SSD Benchmark to all Instances with SSD Instance Storage

### DIFF
--- a/ssd_bandwidth/configuration.yml
+++ b/ssd_bandwidth/configuration.yml
@@ -7,6 +7,11 @@ configuration:
     instance-number: 1
     instance-types:
       - i4g.large
+      - i4i.large
+      - is4gen.large
+      - i3.large
+      - i3en.large
+      - im4gn.large
 
 nodes:
   - node-id: 0


### PR DESCRIPTION
- Dynamically detect a non-boot device
- Extend the list of instances to run on